### PR TITLE
Fix compile issues due to duplicate symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,4 +40,4 @@ install:
 	cp hex2bin.1 $(MAN_DIR)
 
 clean:
-	rm core *.o hex2bin mot2bin
+	rm -f core *.o hex2bin mot2bin

--- a/common.c
+++ b/common.c
@@ -25,6 +25,7 @@
   20170304 JP: added the 16-bit checksum 8-bit wide
 */
 
+#define __COMMON_C__
 #include "common.h"
 
 filetype    Filename;           /* string for opening files */

--- a/common.h
+++ b/common.h
@@ -74,55 +74,57 @@ void GetFilename(char *dest,char *src);
 void GetExtension(const char *str,char *ext);
 void PutExtension(char *Flnm, char *Extension);
 
-filetype    Filename;           /* string for opening files */
-char        Extension[MAX_EXTENSION_SIZE];       /* filename extension for output files */
+#ifndef __COMMON_C__
+extern filetype    Filename;           /* string for opening files */
+extern char        Extension[MAX_EXTENSION_SIZE];       /* filename extension for output files */
 
-FILE        *Filin,             /* input files */
+extern FILE        *Filin,             /* input files */
             *Filout;            /* output files */
 
 #ifdef USE_FILE_BUFFERS
-char		*FilinBuf,          /* text buffer for file input */
+extern char		*FilinBuf,          /* text buffer for file input */
             *FiloutBuf;         /* text buffer for file output */
 #endif
 
-int Pad_Byte;
-bool Enable_Checksum_Error;
-bool Status_Checksum_Error;
-byte 	Checksum;
-unsigned int Record_Nb;
-unsigned int Nb_Bytes;
+extern int Pad_Byte;
+extern bool Enable_Checksum_Error;
+extern bool Status_Checksum_Error;
+extern byte 	Checksum;
+extern unsigned int Record_Nb;
+extern unsigned int Nb_Bytes;
 
 /* This will hold binary codes translated from hex file. */
-byte *Memory_Block;
-unsigned int Lowest_Address, Highest_Address;
-unsigned int Starting_Address, Phys_Addr;
-unsigned int Records_Start; // Lowest address of the records
-unsigned int Max_Length;
-unsigned int Minimum_Block_Size;
-unsigned int Ceiling_Address;
-unsigned int Floor_Address;
-int Module;
-bool Minimum_Block_Size_Setted;
-bool Starting_Address_Setted;
-bool Floor_Address_Setted;
-bool Ceiling_Address_Setted;
-bool Max_Length_Setted;
-bool Swap_Wordwise;
-bool Address_Alignment_Word;
-bool Batch_Mode;
-bool Verbose_Flag;
+extern byte *Memory_Block;
+extern unsigned int Lowest_Address, Highest_Address;
+extern unsigned int Starting_Address, Phys_Addr;
+extern unsigned int Records_Start; // Lowest address of the records
+extern unsigned int Max_Length;
+extern unsigned int Minimum_Block_Size;
+extern unsigned int Ceiling_Address;
+extern unsigned int Floor_Address;
+extern int Module;
+extern bool Minimum_Block_Size_Setted;
+extern bool Starting_Address_Setted;
+extern bool Floor_Address_Setted;
+extern bool Ceiling_Address_Setted;
+extern bool Max_Length_Setted;
+extern bool Swap_Wordwise;
+extern bool Address_Alignment_Word;
+extern bool Batch_Mode;
+extern bool Verbose_Flag;
 
-int Endian;
+extern int Endian;
 
-t_CRC Cks_Type;
-unsigned int Cks_Start, Cks_End, Cks_Addr, Cks_Value;
-bool Cks_range_set;
-bool Cks_Addr_set;
-bool Force_Value;
+extern t_CRC Cks_Type;
+extern unsigned int Cks_Start, Cks_End, Cks_Addr, Cks_Value;
+extern bool Cks_range_set;
+extern bool Cks_Addr_set;
+extern bool Force_Value;
 
-unsigned int Crc_Poly, Crc_Init, Crc_XorOut;
-bool Crc_RefIn;
-bool Crc_RefOut;
+extern unsigned int Crc_Poly, Crc_Init, Crc_XorOut;
+extern bool Crc_RefIn;
+extern bool Crc_RefOut;
+#endif
 
 void VerifyChecksumValue(void);
 void VerifyRangeFloorCeil(void);

--- a/libcrc.h
+++ b/libcrc.h
@@ -24,7 +24,7 @@
 #ifndef _LIBCRC_H_
 #define _LIBCRC_H_
 
-void *crc_table;
+extern void *crc_table;
 
 void init_crc8_normal_tab(uint8_t polynom);
 void init_crc8_reflected_tab(uint8_t polynom);


### PR DESCRIPTION
Tested on:
  - Ubuntu 22.04.3 LTS, gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
  - Debian GNU/Linux 12 (bookworm), gcc (Debian 12.2.0-14) 12.2.0
  - MacOS Sonoma 14.1.2 (23B92), Apple clang version 15.0.0 (clang-1500.1.0.2.5)